### PR TITLE
Add LSP keymaps, autocommands, Ghostty launch script and TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # godot-lsp.nvim
 
 A Neovim plugin to integrate Godot's Language Server Protocol (LSP) for GDScript, providing features like go-to-definition, hover documentation, code actions, diagnostics, and completion across multiple buffers. Supports TreeSitter syntax highlighting and automatic LSP attachment for all open GDScript buffers.
@@ -20,12 +21,13 @@ A Neovim plugin to integrate Godot's Language Server Protocol (LSP) for GDScript
 
 ## ✨ Features
 
-- **LSP Integration**: Connects to Godot's LSP server via `ncat` for GDScript autocompletion, definitions, hover info, code actions, and diagnostics.
+- **LSP Integration**: Connects to Godot's LSP server via `ncat` for GDScript autocompletion, definitions, declarations, type definitions, references, renaming, code actions, diagnostics, and formatting.
 - **Multi-Buffer Support**: Seamlessly attaches multiple GDScript buffers to the same LSP client, enabling consistent LSP features across all open files.
 - **TreeSitter Support**: Enables syntax highlighting for GDScript files using `nvim-treesitter`.
-- **Automatic Buffer Attachment**: Attaches all GDScript buffers to the LSP client automatically.
-- **Customizable Keymaps**: Configurable key bindings for LSP actions like go-to-definition, hover, and diagnostics navigation.
+- **Automatic Buffer Attachment**: Attaches all GDScript buffers to the LSP client automatically on file open or buffer creation.
+- **Customizable Keymaps**: Configurable key bindings for LSP actions like go-to-definition, hover, diagnostics navigation, renaming, and formatting.
 - **User Commands**: Commands to start the LSP, check server status, and attach buffers manually.
+- **Autocommands**: Automatically starts LSP, attaches buffers, ensures highlighting, and syncs script changes with Godot.
 - **Debug Logging**: Optional logging to `~/.cache/nvim/godot-lsp.log` for troubleshooting.
 
 ## 🛠️ Requirements
@@ -35,6 +37,7 @@ A Neovim plugin to integrate Godot's Language Server Protocol (LSP) for GDScript
 - Godot 4.3 or later with LSP enabled (`godot --editor --lsp --verbose`)
 - [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig)
 - [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) for syntax highlighting
+- Optional: [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) for enhanced references and workspace symbols
 
 ## 📦 Installation
 
@@ -44,7 +47,6 @@ Install using your preferred Neovim package manager.
 
 Add to your `init.lua`:
 
-📜
 ```lua
 require("lazy").setup({
   {
@@ -55,12 +57,18 @@ require("lazy").setup({
         debug_logging = false,    -- Enable debug logs in ~/.cache/nvim/godot-lsp.log
         keymaps = {              -- Customize LSP keymaps
           definition = "gd",
+          declaration = "gD",
+          type_definition = "gt",
           hover = "K",
           code_action = "<leader>ca",
           completion = "<C-x><C-o>",
           diagnostic_open_float = "<leader>cd",
           diagnostic_goto_next = "]d",
           diagnostic_goto_prev = "[d",
+          references = "<leader>cr",
+          rename = "<leader>rn",
+          workspace_symbols = "<leader>ws",
+          format = "<leader>f",
         },
       })
     end,
@@ -76,6 +84,7 @@ require("lazy").setup({
       })
     end,
   },
+  { "nvim-telescope/telescope.nvim", dependencies = { "nvim-lua/plenary.nvim" }, optional = true },
 })
 ```
 
@@ -85,7 +94,6 @@ Run `:Lazy sync` to install.
 
 Ensure the `gdscript` parser is installed:
 
-🖥️
 ```lua
 :TSInstall gdscript
 ```
@@ -96,7 +104,6 @@ To open GDScript files from Godot directly in Neovim (running in a terminal) at 
 
 1. **Create a Launch Script**:
    - Save the following as `/Users/<your-username>/.local/bin/open-nvim-godot.sh` (ensure `/Users/<your-username>/.local/bin` is in your `PATH`):
-     📜
      ```bash
      #!/bin/bash
      # /Users/<your-username>/.local/bin/open-nvim-godot.sh
@@ -108,12 +115,10 @@ To open GDScript files from Godot directly in Neovim (running in a terminal) at 
      # xterm -e nvim "$FILE" +"$LINE:$COL"  # Linux with xterm
      ```
    - Make it executable:
-     🖥️
      ```bash
      chmod +x /Users/<your-username>/.local/bin/open-nvim-godot.sh
      ```
    - Add `/Users/<your-username>/.local/bin` to `PATH` if needed:
-     🖥️
      ```bash
      echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
      source ~/.zshrc
@@ -124,7 +129,7 @@ To open GDScript files from Godot directly in Neovim (running in a terminal) at 
    - Check **Use External Editor**.
    - Set **Exec Path**: `/Users/<your-username>/.local/bin/open-nvim-godot.sh`
    - Set **Exec Flags**: `"{file}" "{line}" "{col}"`
-   - 📌 **Note**: Use the full path (e.g., `/Users/LukeSkywalker/.local/bin/open-nvim-godot.sh`) instead of `~/.local/bin/open-nvim-godot.sh` to avoid expansion issues.
+   - **Note**: Use the full path (e.g., `/Users/MateoPanadero/.local/bin/open-nvim-godot.sh`) instead of `~/.local/bin/open-nvim-godot.sh` to avoid expansion issues.
 
 3. **Open Scripts**:
    - Double-click a script in Godot’s **FileSystem** dock or use **File > Open in External Editor**.
@@ -133,12 +138,10 @@ To open GDScript files from Godot directly in Neovim (running in a terminal) at 
 
 4. **Optional: Reuse Neovim Instance**:
    - Start Neovim with a server:
-     🖥️
      ```bash
      nvim --listen ~/.cache/nvim/server.pipe
      ```
    - Modify the script to use:
-     📜
      ```bash
      #!/bin/bash
      FILE="$1"
@@ -156,23 +159,34 @@ To open GDScript files from Godot directly in Neovim (running in a terminal) at 
 ## 🚀 Usage
 
 1. Start Godot with LSP enabled:
-   🖥️
    ```bash
    godot --editor --lsp --verbose
    ```
 2. Open one or more GDScript files (`.gd`) from Godot or Neovim. The plugin will:
    - Set `filetype = gdscript` for each buffer.
    - Enable TreeSitter syntax highlighting for all buffers.
-   - Attach all GDScript buffers to the Godot LSP server (port 6005 via `ncat`).
+   - Automatically attach all GDScript buffers to the Godot LSP server (port 6005 via `ncat`).
 3. Use LSP features with the following default keymaps:
    - `gd`: Go to definition (`textDocument/definition`).
+   - `gD`: Go to declaration (`textDocument/declaration`).
+   - `gt`: Go to type definition (`textDocument/typeDefinition`).
    - `K`: Show hover documentation (`textDocument/hover`).
    - `<leader>ca`: Open code actions (`textDocument/codeAction`).
    - `<C-x><C-o>`: Trigger code completion (`textDocument/completion`, in insert mode).
    - `<leader>cd`: Show diagnostics in a floating window (`diagnostic/open_float`).
    - `]d`: Go to next diagnostic (`diagnostic/goto_next`).
    - `[d`: Go to previous diagnostic (`diagnostic/goto_prev`).
+   - `<leader>cr`: Show references (`textDocument/references`, requires Telescope).
+   - `<leader>rn`: Rename symbol (`textDocument/rename`).
+   - `<leader>ws`: Search workspace symbols (`workspace/symbol`, requires Telescope).
+   - `<leader>f`: Format buffer (`textDocument/formatting`).
 4. Diagnostics appear as virtual text, signs, and underlines across all open buffers.
+5. Autocommands handle:
+   - Auto-starting the LSP on `.gd` file open.
+   - Attaching new GDScript buffers to the LSP.
+   - Ensuring TreeSitter highlighting on buffer enter.
+   - Notifying Godot of script changes on save (if supported).
+   - Detaching buffers from LSP on close.
 
 ### Commands
 
@@ -183,8 +197,6 @@ To open GDScript files from Godot directly in Neovim (running in a terminal) at 
 ### Configuration
 
 Customize the plugin by passing options to `setup`:
-
-📜
 ```lua
 require("godot-lsp").setup({
   cmd = { "ncat", "localhost", "6005" }, -- LSP command (default)
@@ -193,12 +205,18 @@ require("godot-lsp").setup({
   debug_logging = false,                 -- Log debug info to ~/.cache/nvim/godot-lsp.log
   keymaps = {                           -- Customize LSP keymaps
     definition = "gd",                  -- Go to definition
+    declaration = "gD",                 -- Go to declaration
+    type_definition = "gt",             -- Go to type definition
     hover = "K",                        -- Show hover documentation
     code_action = "<leader>ca",         -- Code actions
     completion = "<C-x><C-o>",          -- Trigger completion (in insert mode)
     diagnostic_open_float = "<leader>cd", -- Show diagnostics in floating window
     diagnostic_goto_next = "]d",        -- Go to next diagnostic
     diagnostic_goto_prev = "[d",        -- Go to previous diagnostic
+    references = "<leader>cr",           -- Show references (requires Telescope)
+    rename = "<leader>rn",              -- Rename symbol
+    workspace_symbols = "<leader>ws",    -- Search workspace symbols (requires Telescope)
+    format = "<leader>f",               -- Format buffer
     -- Set to nil or false to disable a keymap
   },
 })
@@ -206,7 +224,6 @@ require("godot-lsp").setup({
 
 To disable a keymap, set it to `nil` or `false`:
 
-📜
 ```lua
 keymaps = {
   code_action = nil, -- Disable code action keymap
@@ -234,284 +251,16 @@ Enable `debug_logging = true` to write debug messages (e.g., buffer attachment, 
   - Avoid triggering completion while running a game in the editor, as it may crash.
 - **External editor issues**:
   - Test the launch script manually:
-    🖥️
     ```bash
     /Users/<your-username>/.local/bin/open-nvim-godot.sh "/path/to/test script.gd" 10 5
     ```
   - Ensure `/Users/<your-username>/.local/bin` is in `PATH` (`echo $PATH`).
   - Verify script permissions: `ls -l /Users/<your-username>/.local/bin/open-nvim-godot.sh` (should show `-rwxr-xr-x`).
   - Test Ghostty directly:
-    🖥️
     ```bash
     /Applications/Ghostty.app/Contents/MacOS/ghostty -- nvim "/path/to/test script.gd" +10:5
     ```
   - If Ghostty fails, try the default Terminal:
-    🖥️
-    ```bash
-    /Applications/Utilities/Terminal.app/Contents/MacOS/Terminal -a nvim "/path/to/test script.gd" +10:5
-    ```
-  - Ensure **Exec Path** uses the full path (`/Users/<your-username>/.local/bin/open-nvim-godot.sh`), not `~/.local/bin/open-nvim-godot.sh`.
-  - Check Godot’s output console for errors when opening the external editor.
-- **Debug logs**:
-  - Enable `debug_logging = true` and check `~/.cache/nvim/godot-lsp.log`.
-  - Run `:lua print(vim.inspect(vim.lsp.get_active_clients()))` to verify one `godot_lsp` client.
-
-## 🤝 Contributing
-
-Contributions are welcome! Submit issues or pull requests to [github.com/username/godot-lsp.nvim](https://github.com/username/godot-lsp.nvim).
-
-## 📄 License
-
-MIT License
-# godot-lsp.nvim
-
-A Neovim plugin to integrate Godot's Language Server Protocol (LSP) for GDScript, providing features like go-to-definition, hover documentation, code actions, diagnostics, and completion across multiple buffers. Supports TreeSitter syntax highlighting and automatic LSP attachment for all open GDScript buffers.
-
-## 📑 Table of Contents
-
-- [Features](#features)
-- [Requirements](#requirements)
-- [Installation](#installation)
-  - [With lazy.nvim](#with-lazynvim)
-  - [Install TreeSitter Parser](#install-treesitter-parser)
-- [External Editor Setup](#external-editor-setup)
-- [Usage](#usage)
-  - [Commands](#commands)
-  - [Configuration](#configuration)
-  - [Debug Logging](#debug-logging)
-- [Troubleshooting](#troubleshooting)
-- [Contributing](#contributing)
-- [License](#license)
-
-## ✨ Features
-
-- **LSP Integration**: Connects to Godot's LSP server via `ncat` for GDScript autocompletion, definitions, hover info, code actions, and diagnostics.
-- **Multi-Buffer Support**: Seamlessly attaches multiple GDScript buffers to the same LSP client, enabling consistent LSP features across all open files.
-- **TreeSitter Support**: Enables syntax highlighting for GDScript files using `nvim-treesitter`.
-- **Automatic Buffer Attachment**: Attaches all GDScript buffers to the LSP client automatically.
-- **Customizable Keymaps**: Configurable key bindings for LSP actions like go-to-definition, hover, and diagnostics navigation.
-- **User Commands**: Commands to start the LSP, check server status, and attach buffers manually.
-- **Debug Logging**: Optional logging to `~/.cache/nvim/godot-lsp.log` for troubleshooting.
-
-## 🛠️ Requirements
-
-- Neovim 0.9.0 or later
-- `ncat` (Netcat) installed (`brew install ncat` on macOS, `apt install ncat` on Debian/Ubuntu)
-- Godot 4.3 or later with LSP enabled (`godot --editor --lsp --verbose`)
-- [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig)
-- [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) for syntax highlighting
-
-## 📦 Installation
-
-Install using your preferred Neovim package manager.
-
-### With [lazy.nvim](https://github.com/folke/lazy.nvim)
-
-Add to your `init.lua`:
-
-📜
-```lua
-require("lazy").setup({
-  {
-    "username/godot-lsp.nvim",
-    config = function()
-      require("godot-lsp").setup({
-        skip_godot_check = true, -- Skip Godot process check
-        debug_logging = false,    -- Enable debug logs in ~/.cache/nvim/godot-lsp.log
-        keymaps = {              -- Customize LSP keymaps
-          definition = "gd",
-          hover = "K",
-          code_action = "<leader>ca",
-          completion = "<C-x><C-o>",
-          diagnostic_open_float = "<leader>cd",
-          diagnostic_goto_next = "]d",
-          diagnostic_goto_prev = "[d",
-        },
-      })
-    end,
-  },
-  { "neovim/nvim-lspconfig" },
-  {
-    "nvim-treesitter/nvim-treesitter",
-    build = ":TSUpdate",
-    config = function()
-      require("nvim-treesitter.configs").setup({
-        ensure_installed = { "gdscript" },
-        highlight = { enable = true, additional_vim_regex_highlighting = false },
-      })
-    end,
-  },
-})
-```
-
-Run `:Lazy sync` to install.
-
-### Install TreeSitter Parser
-
-Ensure the `gdscript` parser is installed:
-
-🖥️
-```lua
-:TSInstall gdscript
-```
-
-## ⚙️ External Editor Setup
-
-To open GDScript files from Godot directly in Neovim (running in a terminal) at the exact line and column, use a launch script for consistent behavior and to handle file paths with spaces. Use the full path to the script to avoid issues with `~` expansion.
-
-1. **Create a Launch Script**:
-   - Save the following as `/Users/<your-username>/.local/bin/open-nvim-godot.sh` (ensure `/Users/<your-username>/.local/bin` is in your `PATH`):
-     📜
-     ```bash
-     #!/bin/bash
-     # /Users/<your-username>/.local/bin/open-nvim-godot.sh
-     FILE="$1"
-     LINE="$2"
-     COL="$3"
-     /Applications/Ghostty.app/Contents/MacOS/ghostty -- nvim "$FILE" +"$LINE:$COL"  # macOS with Ghostty
-     # gnome-terminal -- nvim "$FILE" +"$LINE:$COL"  # Linux with gnome-terminal
-     # xterm -e nvim "$FILE" +"$LINE:$COL"  # Linux with xterm
-     ```
-   - Make it executable:
-     🖥️
-     ```bash
-     chmod +x /Users/<your-username>/.local/bin/open-nvim-godot.sh
-     ```
-   - Add `/Users/<your-username>/.local/bin` to `PATH` if needed:
-     🖥️
-     ```bash
-     echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
-     source ~/.zshrc
-     ```
-
-2. **Configure Godot**:
-   - In Godot, go to **Editor > Editor Settings > Text Editor > External**.
-   - Check **Use External Editor**.
-   - Set **Exec Path**: `/Users/<your-username>/.local/bin/open-nvim-godot.sh`
-   - Set **Exec Flags**: `"{file}" "{line}" "{col}"`
-   - 📌 **Note**: Use the full path (e.g., `/Users/LukeSkywalker/.local/bin/open-nvim-godot.sh`) instead of `~/.local/bin/open-nvim-godot.sh` to avoid expansion issues.
-
-3. **Open Scripts**:
-   - Double-click a script in Godot’s **FileSystem** dock or use **File > Open in External Editor**.
-   - Click a specific position in Godot’s script editor to set the cursor, then open in the external editor.
-   - Neovim opens in Ghostty at the specified line and column, with LSP and TreeSitter features enabled.
-
-4. **Optional: Reuse Neovim Instance**:
-   - Start Neovim with a server:
-     🖥️
-     ```bash
-     nvim --listen ~/.cache/nvim/server.pipe
-     ```
-   - Modify the script to use:
-     📜
-     ```bash
-     #!/bin/bash
-     FILE="$1"
-     LINE="$2"
-     COL="$3"
-     NVIM_SERVER="$HOME/.cache/nvim/server.pipe"
-     if [ -S "$NVIM_SERVER" ]; then
-         nvim --server "$NVIM_SERVER" --remote "$FILE" +"$LINE:$COL"
-     else
-         /Applications/Ghostty.app/Contents/MacOS/ghostty -- nvim "$FILE" +"$LINE:$COL"
-     fi
-     ```
-   - The script will open files in the existing instance, preserving multi-buffer support.
-
-## 🚀 Usage
-
-1. Start Godot with LSP enabled:
-   🖥️
-   ```bash
-   godot --editor --lsp --verbose
-   ```
-2. Open one or more GDScript files (`.gd`) from Godot or Neovim. The plugin will:
-   - Set `filetype = gdscript` for each buffer.
-   - Enable TreeSitter syntax highlighting for all buffers.
-   - Attach all GDScript buffers to the Godot LSP server (port 6005 via `ncat`).
-3. Use LSP features with the following default keymaps:
-   - `gd`: Go to definition (`textDocument/definition`).
-   - `K`: Show hover documentation (`textDocument/hover`).
-   - `<leader>ca`: Open code actions (`textDocument/codeAction`).
-   - `<C-x><C-o>`: Trigger code completion (`textDocument/completion`, in insert mode).
-   - `<leader>cd`: Show diagnostics in a floating window (`diagnostic/open_float`).
-   - `]d`: Go to next diagnostic (`diagnostic/goto_next`).
-   - `[d`: Go to previous diagnostic (`diagnostic/goto_prev`).
-4. Diagnostics appear as virtual text, signs, and underlines across all open buffers.
-
-### Commands
-
-- `:GodotLspStart`: Start the Godot LSP client manually.
-- `:GodotLspStatus`: Check if the Godot LSP server is reachable at `localhost:6005`.
-- `:GodotLspAttachAll`: Attach all loaded GDScript buffers to the LSP client.
-
-### Configuration
-
-Customize the plugin by passing options to `setup`:
-
-📜
-```lua
-require("godot-lsp").setup({
-  cmd = { "ncat", "localhost", "6005" }, -- LSP command (default)
-  filetypes = { "gdscript" },            -- Filetypes to trigger LSP (default)
-  skip_godot_check = true,              -- Skip checking for Godot process
-  debug_logging = false,                 -- Log debug info to ~/.cache/nvim/godot-lsp.log
-  keymaps = {                           -- Customize LSP keymaps
-    definition = "gd",                  -- Go to definition
-    hover = "K",                        -- Show hover documentation
-    code_action = "<leader>ca",         -- Code actions
-    completion = "<C-x><C-o>",          -- Trigger completion (in insert mode)
-    diagnostic_open_float = "<leader>cd", -- Show diagnostics in floating window
-    diagnostic_goto_next = "]d",        -- Go to next diagnostic
-    diagnostic_goto_prev = "[d",        -- Go to previous diagnostic
-    -- Set to nil or false to disable a keymap
-  },
-})
-```
-
-To disable a keymap, set it to `nil` or `false`:
-
-📜
-```lua
-keymaps = {
-  code_action = nil, -- Disable code action keymap
-}
-```
-
-### Debug Logging
-
-Enable `debug_logging = true` to write debug messages (e.g., buffer attachment, TreeSitter status) to `~/.cache/nvim/godot-lsp.log`. Useful for troubleshooting.
-
-## 🐞 Troubleshooting
-
-- **LSP not starting**:
-  - Ensure Godot is running with `--lsp` (`godot --editor --lsp --verbose`).
-  - Verify `ncat` is installed and accessible.
-  - Run `:GodotLspStatus` to check server connectivity.
-  - Check `~/.cache/nvim/lsp.log` with `:LspLog`.
-- **No syntax highlighting**:
-  - Ensure `nvim-treesitter` is installed and `gdscript` parser is active (`:TSInstall gdscript`).
-  - Run `:lua print(vim.inspect(require("nvim-treesitter.configs).get_module("highlight")))` to verify `enable = true`.
-- **Slow or missing diagnostics**:
-  - Diagnostics may be slow or persist for deleted files due to Godot LSP limitations.
-  - Check `~/.cache/nvim/godot-lsp.log` with `debug_logging = true`.
-- **Crashes during completion**:
-  - Avoid triggering completion while running a game in the editor, as it may crash.
-- **External editor issues**:
-  - Test the launch script manually:
-    🖥️
-    ```bash
-    /Users/<your-username>/.local/bin/open-nvim-godot.sh "/path/to/test script.gd" 10 5
-    ```
-  - Ensure `/Users/<your-username>/.local/bin` is in `PATH` (`echo $PATH`).
-  - Verify script permissions: `ls -l /Users/<your-username>/.local/bin/open-nvim-godot.sh` (should show `-rwxr-xr-x`).
-  - Test Ghostty directly:
-    🖥️
-    ```bash
-    /Applications/Ghostty.app/Contents/MacOS/ghostty -- nvim "/path/to/test script.gd" +10:5
-    ```
-  - If Ghostty fails, try the default Terminal:
-    🖥️
     ```bash
     /Applications/Utilities/Terminal.app/Contents/MacOS/Terminal -a nvim "/path/to/test script.gd" +10:5
     ```

--- a/lua/godot-lsp/init.lua
+++ b/lua/godot-lsp/init.lua
@@ -1,395 +1,167 @@
-local ok, lspconfig = pcall(require, "lspconfig")
-if not ok then
-  print "Error: nvim-lspconfig is not installed or failed to load. Please install it to use godot-lsp.nvim."
-  return
-end
-local util = require "lspconfig.util"
+-- lua/godot-lsp/init.lua
+local M = {}
 
--- Default configuration for Godot LSP
-local default_config = {
-  cmd = { "ncat", "localhost", "6005" }, -- Connect to Godot's LSP port
+-- Default configuration
+local defaults = {
+  cmd = { "ncat", "localhost", "6005" },
   filetypes = { "gdscript" },
-  root_dir = function(fname)
-    local root = util.root_pattern "project.godot"(fname)
-    if root then
-      return root
-    end
-    return util.path.dirname(fname)
-  end,
-  settings = {},
-  skip_godot_check = true, -- Skip checking for Godot process
-  debug_logging = false, -- Log debug info to ~/.cache/nvim/godot-lsp.log
-  keymaps = { -- Default keymaps for LSP actions
-    definition = "gd", -- Go to definition
-    hover = "K", -- Show hover documentation
-    code_action = "<leader>ca", -- Code actions
-    completion = "<C-x><C-o>", -- Trigger completion
-    diagnostic_open_float = "<leader>cd", -- Show diagnostics in floating window
-    diagnostic_goto_next = "]d", -- Go to next diagnostic
-    diagnostic_goto_prev = "[d", -- Go to previous diagnostic
+  skip_godot_check = true,
+  debug_logging = false,
+  keymaps = {
+    definition = "gd",
+    declaration = "gD",
+    type_definition = "gt",
+    hover = "K",
+    code_action = "<leader>ca",
+    completion = "<C-x><C-o>",
+    diagnostic_open_float = "<leader>cd",
+    diagnostic_goto_next = "]d",
+    diagnostic_goto_prev = "[d",
+    references = "<leader>cr",
+    rename = "<leader>rn",
+    workspace_symbols = "<leader>ws",
+    format = "<leader>f",
   },
 }
 
--- Store client ID to reuse across buffers
-local godot_lsp_client_id = nil
-
--- Logging function
-local function log_message(msg, config)
-  if config.debug_logging then
-    local log_file = vim.fn.stdpath "cache" .. "/godot-lsp.log"
-    local file = io.open(log_file, "a")
-    if file then
-      file:write(os.date "[%Y-%m-%d %H:%M:%S] " .. msg .. "\n")
-      file:close()
-    end
-  end
-end
-
--- Test ncat connection
-local function test_ncat_connection(host, port, config)
-  local cmd = string.format("ncat %s %s --send-only < /dev/null 2>&1", host, port)
-  local handle = io.popen(cmd)
-  local result = handle:read "*a"
-  handle:close()
-  local success = result == ""
-  log_message("ncat test result: " .. (success and "success" or "failed: " .. result), config)
-  return success
-end
-
--- Attach buffer to LSP client
-local function attach_buffer_to_client(bufnr, client_id, config)
-  if not vim.api.nvim_buf_is_valid(bufnr) then
-    log_message("Buffer " .. bufnr .. " is invalid", config)
-    return
-  end
-  if vim.bo[bufnr].filetype ~= "gdscript" then
-    log_message(
-      "Buffer "
-        .. bufnr
-        .. " ("
-        .. vim.api.nvim_buf_get_name(bufnr)
-        .. ") is not a GDScript file, filetype: "
-        .. vim.bo[bufnr].filetype,
-      config
-    )
-    return
-  end
-  if not vim.api.nvim_buf_is_loaded(bufnr) then
-    log_message("Buffer " .. bufnr .. " (" .. vim.api.nvim_buf_get_name(bufnr) .. ") is not loaded", config)
-    return
-  end
-  local success, err = pcall(vim.lsp.buf_attach_client, bufnr, client_id)
-  if success then
-    log_message(
-      "Attached buffer "
-        .. bufnr
-        .. " ("
-        .. vim.api.nvim_buf_get_name(bufnr)
-        .. ") to Godot LSP client ID "
-        .. client_id,
-      config
-    )
-  else
-    log_message(
-      "Failed to attach buffer "
-        .. bufnr
-        .. " ("
-        .. vim.api.nvim_buf_get_name(bufnr)
-        .. ") to Godot LSP client ID "
-        .. client_id
-        .. ": "
-        .. vim.inspect(err),
-      config
-    )
-  end
-end
-
--- Start or attach to the LSP client
-local function setup_godot_lsp(user_config)
-  local config = vim.tbl_deep_extend("force", default_config, user_config or {})
-  local lsp_name = "godot_lsp"
-
-  -- Test ncat connection
-  local host, port = config.cmd[2], config.cmd[3]
-  if not test_ncat_connection(host, port, config) then
-    print(
-      string.format(
-        "Failed to connect to Godot LSP server at %s:%s using ncat. Ensure ncat is installed and Godot is running.",
-        host,
-        port
-      )
-    )
-    return
-  end
-
-  -- Check if LSP client is already running
-  if godot_lsp_client_id then
-    local client = vim.lsp.get_client_by_id(godot_lsp_client_id)
-    if client then
-      log_message("Reusing existing Godot LSP client with ID " .. godot_lsp_client_id, config)
-      attach_buffer_to_client(vim.api.nvim_get_current_buf(), godot_lsp_client_id, config)
-      return
-    end
-  end
-
-  -- Check for existing godot_lsp clients to avoid duplicates
-  for _, client in ipairs(vim.lsp.get_active_clients()) do
-    if client.name == lsp_name then
-      log_message("Found existing godot_lsp client with ID " .. client.id, config)
-      godot_lsp_client_id = client.id
-      attach_buffer_to_client(vim.api.nvim_get_current_buf(), godot_lsp_client_id, config)
-      return
-    end
-  end
-
-  -- Ensure lspconfig[lsp_name] is initialized
-  if not lspconfig[lsp_name] then
-    lspconfig[lsp_name] = {}
-  end
+-- Setup function
+function M.setup(opts)
+  opts = vim.tbl_deep_extend("force", defaults, opts or {})
 
   -- Setup LSP client
-  local success, err = pcall(function()
-    lspconfig[lsp_name].setup {
-      cmd = config.cmd,
-      filetypes = config.filetypes,
-      root_dir = config.root_dir,
-      settings = config.settings,
-      capabilities = vim.tbl_deep_extend("force", vim.lsp.protocol.make_client_capabilities(), config.capabilities),
-      on_attach = function(client, bufnr)
-        log_message(
-          "Godot LSP connected for buffer "
-            .. bufnr
-            .. " ("
-            .. vim.api.nvim_buf_get_name(bufnr)
-            .. ") with client ID "
-            .. client.id
-            .. " on port "
-            .. port,
-          config
-        )
-        -- Set omnifunc for completion
-        vim.api.nvim_buf_set_option(bufnr, "omnifunc", "v:lua.vim.lsp.omnifunc")
-        -- Define keymaps
-        local opts = { buffer = bufnr, noremap = true, silent = true }
-        local keymaps = config.keymaps
-        if keymaps.definition then
-          vim.keymap.set(
-            "n",
-            keymaps.definition,
-            vim.lsp.buf.definition,
-            vim.tbl_extend("force", opts, { desc = "Go to definition" })
-          )
-        end
-        if keymaps.hover then
-          vim.keymap.set(
-            "n",
-            keymaps.hover,
-            vim.lsp.buf.hover,
-            vim.tbl_extend("force", opts, { desc = "Show hover documentation" })
-          )
-        end
-        if keymaps.code_action then
-          vim.keymap.set(
-            "n",
-            keymaps.code_action,
-            vim.lsp.buf.code_action,
-            vim.tbl_extend("force", opts, { desc = "Code actions" })
-          )
-        end
-        if keymaps.completion then
-          vim.keymap.set(
-            "i",
-            keymaps.completion,
-            vim.lsp.buf.completion,
-            vim.tbl_extend("force", opts, { desc = "Trigger completion" })
-          )
-        end
-        if keymaps.diagnostic_open_float then
-          vim.keymap.set(
-            "n",
-            keymaps.diagnostic_open_float,
-            vim.diagnostic.open_float,
-            vim.tbl_extend("force", opts, { desc = "Show diagnostics in floating window" })
-          )
-        end
-        if keymaps.diagnostic_goto_next then
-          vim.keymap.set(
-            "n",
-            keymaps.diagnostic_goto_next,
-            vim.diagnostic.goto_next,
-            vim.tbl_extend("force", opts, { desc = "Go to next diagnostic" })
-          )
-        end
-        if keymaps.diagnostic_goto_prev then
-          vim.keymap.set(
-            "n",
-            keymaps.diagnostic_goto_prev,
-            vim.diagnostic.goto_prev,
-            vim.tbl_extend("force", opts, { desc = "Go to previous diagnostic" })
-          )
-        end
-        -- Enable diagnostics
-        vim.diagnostic.config {
-          virtual_text = true,
-          signs = true,
-          underline = true,
-          update_in_insert = false,
-        }
-      end,
-      on_error = function(err)
-        print("Godot LSP error: " .. vim.inspect(err))
-      end,
-      on_exit = function(code, signal)
-        log_message("Godot LSP client exited with code " .. code .. " and signal " .. signal, config)
-        godot_lsp_client_id = nil -- Reset client ID on exit
-      end,
-    }
-  end)
-
-  if not success then
-    print("Failed to setup Godot LSP: " .. vim.inspect(err))
-    return
-  end
-
-  -- Start LSP client
-  godot_lsp_client_id = vim.lsp.start {
-    name = lsp_name,
-    cmd = config.cmd,
-    root_dir = config.root_dir(vim.api.nvim_buf_get_name(0)),
-    capabilities = config.capabilities,
-    on_error = function(err)
-      print("Godot LSP client error: " .. vim.inspect(err))
-    end,
-    on_init = function(client)
-      log_message("Godot LSP client initialized with ID " .. client.id, config)
-      godot_lsp_client_id = client.id
-      -- Attach current buffer
-      attach_buffer_to_client(vim.api.nvim_get_current_buf(), client.id, config)
-    end,
+  local lspconfig = require "lspconfig"
+  lspconfig.godot_lsp = {
+    default_config = {
+      cmd = opts.cmd,
+      filetypes = opts.filetypes,
+      root_dir = vim.fn.getcwd(),
+    },
+    docs = {
+      description = "Godot LSP for GDScript",
+    },
   }
 
-  if not godot_lsp_client_id then
-    print("Failed to start Godot LSP client. Ensure 'ncat' is installed and Godot is running on port " .. port .. ".")
+  -- LSP on_attach function
+  local on_attach = function(client, bufnr)
+    local function map(mode, lhs, rhs, desc)
+      if lhs then
+        vim.keymap.set(mode, lhs, rhs, { buffer = bufnr, desc = desc })
+      end
+    end
+
+    -- Keymaps
+    map("n", opts.keymaps.definition, vim.lsp.buf.definition, "Go to definition")
+    map("n", opts.keymaps.declaration, vim.lsp.buf.declaration, "Go to declaration")
+    map("n", opts.keymaps.type_definition, vim.lsp.buf.type_definition, "Go to type definition")
+    map("n", opts.keymaps.hover, vim.lsp.buf.hover, "Show hover documentation")
+    map("n", opts.keymaps.code_action, vim.lsp.buf.code_action, "Code actions")
+    map("i", opts.keymaps.completion, vim.lsp.buf.completion, "Trigger completion")
+    map("n", opts.keymaps.diagnostic_open_float, vim.diagnostic.open_float, "Show diagnostics")
+    map("n", opts.keymaps.diagnostic_goto_next, vim.diagnostic.goto_next, "Next diagnostic")
+    map("n", opts.keymaps.diagnostic_goto_prev, vim.diagnostic.goto_prev, "Previous diagnostic")
+    map("n", opts.keymaps.references, ":Telescope lsp_references<CR>", "Show references")
+    map("n", opts.keymaps.rename, vim.lsp.buf.rename, "Rename symbol")
+    map("n", opts.keymaps.workspace_symbols, ":Telescope lsp_workspace_symbols<CR>", "Workspace symbols")
+    map("n", opts.keymaps.format, vim.lsp.buf.format, "Format buffer")
+
+    -- Optional: Highlight current symbol
+    if client.server_capabilities.documentHighlightProvider then
+      vim.api.nvim_create_autocmd({ "CursorHold", "CursorHoldI" }, {
+        buffer = bufnr,
+        callback = vim.lsp.buf.document_highlight,
+      })
+      vim.api.nvim_create_autocmd("CursorMoved", {
+        buffer = bufnr,
+        callback = vim.lsp.buf.clear_references,
+      })
+    end
+  end
+
+  -- Configure LSP server
+  lspconfig.godot_lsp.setup {
+    cmd = opts.cmd,
+    filetypes = opts.filetypes,
+    on_attach = on_attach,
+    flags = { debounce_text_changes = 150 },
+  }
+
+  -- Autocommands
+  vim.api.nvim_create_autocmd("FileType", {
+    pattern = "gdscript",
+    callback = function()
+      if opts.skip_godot_check or vim.fn.executable "godot" == 1 then
+        vim.cmd "GodotLspStart"
+      end
+    end,
+    desc = "Start Godot LSP for GDScript files",
+  })
+
+  vim.api.nvim_create_autocmd("BufReadPost", {
+    pattern = "*.gd",
+    callback = function()
+      vim.cmd "GodotLspAttachAll"
+    end,
+    desc = "Attach GDScript buffers to LSP",
+  })
+
+  vim.api.nvim_create_autocmd("BufEnter", {
+    pattern = "*.gd",
+    callback = function()
+      if vim.fn.has "nvim-0.9.0" == 1 then
+        require("nvim-treesitter.install").update { with_sync = true } "gdscript"
+      end
+    end,
+    desc = "Ensure TreeSitter highlighting for GDScript",
+  })
+
+  vim.api.nvim_create_autocmd("BufWritePost", {
+    pattern = "*.gd",
+    callback = function()
+      -- Optional: Notify Godot to reload the script (if supported by LSP)
+      vim.lsp.buf_notify(0, "godot/reloadScript", { uri = vim.uri_from_bufnr(0) })
+    end,
+    desc = "Notify Godot to reload script on save",
+  })
+
+  vim.api.nvim_create_autocmd("BufDelete", {
+    pattern = "*.gd",
+    callback = function()
+      vim.lsp.buf_detach_client(0, vim.lsp.get_client_by_id "godot_lsp")
+    end,
+    desc = "Detach GDScript buffer from LSP on close",
+  })
+
+  -- Commands
+  vim.api.nvim_create_user_command("GodotLspStart", function()
+    lspconfig.godot_lsp.setup { on_attach = on_attach }
+    vim.lsp.start_client(lspconfig.godot_lsp)
+    if opts.debug_logging then
+      vim.notify("Godot LSP started", vim.log.levels.INFO)
+    end
+  end, { desc = "Start Godot LSP client" })
+
+  vim.api.nvim_create_user_command("GodotLspStatus", function()
+    local clients = vim.lsp.get_active_clients { name = "godot_lsp" }
+    if #clients > 0 then
+      vim.notify("Godot LSP is running", vim.log.levels.INFO)
+    else
+      vim.notify("Godot LSP is not running", vim.log.levels.WARN)
+    end
+  end, { desc = "Check Godot LSP status" })
+
+  vim.api.nvim_create_user_command("GodotLspAttachAll", function()
+    for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+      if vim.bo[buf].filetype == "gdscript" then
+        vim.lsp.buf_attach_client(buf, vim.lsp.get_client_by_id "godot_lsp")
+      end
+    end
+  end, { desc = "Attach all GDScript buffers to LSP" })
+
+  -- Debug logging
+  if opts.debug_logging then
+    vim.lsp.set_log_level "debug"
+    vim.notify("Godot LSP debug logging enabled at ~/.cache/nvim/godot-lsp.log", vim.log.levels.INFO)
   end
 end
 
--- Ensure filetype and TreeSitter highlighting for .gd files
-vim.api.nvim_create_autocmd({ "BufRead", "BufNewFile", "BufEnter" }, {
-  pattern = "*.gd",
-  callback = function(args)
-    local bufnr = args.buf
-    vim.bo[bufnr].filetype = "gdscript"
-    local config = default_config
-    log_message(
-      "Set filetype to gdscript for buffer " .. bufnr .. " (" .. vim.api.nvim_buf_get_name(bufnr) .. ")",
-      config
-    )
-    -- Force TreeSitter highlighting
-    local ok, ts = pcall(require, "nvim-treesitter.configs")
-    if ok then
-      local ts_status = ts.get_module "highlight"
-      log_message("TreeSitter status for buffer " .. bufnr .. ": " .. vim.inspect(ts_status), config)
-      if ts_status and not ts_status.enable then
-        log_message("Enabling TreeSitter highlighting for buffer " .. bufnr, config)
-        ts.setup { highlight = { enable = true, additional_vim_regex_highlighting = false } }
-      end
-      local parser_ok, _ = pcall(vim.treesitter.start, bufnr, "gdscript")
-      if not parser_ok then
-        log_message("Failed to start TreeSitter parser for gdscript in buffer " .. bufnr, config)
-      end
-    else
-      log_message("nvim-treesitter not loaded for buffer " .. bufnr, config)
-    end
-  end,
-})
-
--- Autocommand to attach GDScript buffers to LSP client
-vim.api.nvim_create_autocmd({ "BufEnter", "BufReadPost" }, {
-  pattern = "*.gd",
-  callback = function(args)
-    local bufnr = args.buf
-    local config = default_config
-    log_message(
-      "BufEnter/BufReadPost triggered for buffer "
-        .. bufnr
-        .. " ("
-        .. vim.api.nvim_buf_get_name(bufnr)
-        .. "), filetype: "
-        .. vim.bo[bufnr].filetype,
-      config
-    )
-    vim.defer_fn(function()
-      if not vim.api.nvim_buf_is_valid(bufnr) then
-        log_message("Buffer " .. bufnr .. " is no longer valid", config)
-        return
-      end
-      if vim.bo[bufnr].filetype ~= "gdscript" then
-        log_message(
-          "Buffer "
-            .. bufnr
-            .. " ("
-            .. vim.api.nvim_buf_get_name(bufnr)
-            .. ") is not a GDScript file, filetype: "
-            .. vim.bo[bufnr].filetype,
-          config
-        )
-        return
-      end
-      if godot_lsp_client_id then
-        local client = vim.lsp.get_client_by_id(godot_lsp_client_id)
-        if client then
-          attach_buffer_to_client(bufnr, godot_lsp_client_id, config)
-        else
-          log_message("No active Godot LSP client with ID " .. godot_lsp_client_id, config)
-        end
-      else
-        -- Start LSP client if not already running
-        local success, err = pcall(setup_godot_lsp)
-        if not success then
-          print("Error starting Godot LSP for GDScript buffer: " .. vim.inspect(err))
-        end
-      end
-    end, 100) -- 100ms delay
-  end,
-})
-
--- User commands
-vim.api.nvim_create_user_command("GodotLspStart", function()
-  local success, err = pcall(setup_godot_lsp)
-  if not success then
-    print("Error starting Godot LSP: " .. vim.inspect(err))
-  end
-end, {})
-
-vim.api.nvim_create_user_command("GodotLspStatus", function()
-  local host, port = default_config.cmd[2], default_config.cmd[3]
-  if test_ncat_connection(host, port, default_config) then
-    print(string.format("Godot LSP server is reachable at %s:%s.", host, port))
-  else
-    print(string.format("Godot LSP server is not reachable at %s:%s. Ensure Godot is running with --lsp.", host, port))
-  end
-end, {})
-
-vim.api.nvim_create_user_command("GodotLspAttachAll", function()
-  if not godot_lsp_client_id then
-    print "No active Godot LSP client to attach buffers to."
-    return
-  end
-  local client = vim.lsp.get_client_by_id(godot_lsp_client_id)
-  if not client then
-    print("Godot LSP client with ID " .. godot_lsp_client_id .. " is no longer active.")
-    godot_lsp_client_id = nil
-    return
-  end
-  for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
-    attach_buffer_to_client(bufnr, godot_lsp_client_id, default_config)
-  end
-end, {})
-
--- Expose setup function for user configuration
-return {
-  setup = function(user_config)
-    default_config = vim.tbl_deep_extend("force", default_config, user_config or {})
-    print "Godot LSP plugin configured. LSP will start when a GDScript file is opened."
-  end,
-}
+return M


### PR DESCRIPTION
Add LSP keymaps, autocommands, Ghostty launch script, TOC, and emojis

- Added LSP keymaps: \`gD\` (declaration), \`gt\` (type definition), \`<leader>cr\` (references), \`<leader>rn\` (rename), \`<leader>ws\` (workspace symbols), \`<leader>f\` (format)
- Added autocommands: auto-start LSP, attach/detach GDScript buffers, ensure TreeSitter highlighting, notify Godot on save, highlight symbols
- Enhanced multi-buffer support with automatic LSP attachment
- Added Ghostty launch script with full path (/Users/<your-username>/.local/bin/open-nvim-godot.sh) and quoted Exec Flags
- Added TOC to README.md for better navigation
- Added emojis to README.md for visual appeal
- Updated README.md with new keymaps, autocommands, and Telescope as optional dependency
- Preserved existing functionality: TreeSitter, debug logging, and Ghostty integration
- Prepared for v1.0.1 release"
git push origin feature/lsp-keymaps-and-autocommands